### PR TITLE
v0.2.0-alpha

### DIFF
--- a/DarkNukeExtensions.sln
+++ b/DarkNukeExtensions.sln
@@ -22,6 +22,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_sampleBuild", "sample\sampleBuild\_sampleBuild.csproj", "{9B5AE033-2D2D-4F80-99E4-49115DBA924F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{3870B8E0-FDCF-420E-99B4-C6E3D8F567A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DarkNukeExtensions.Tests", "tests\DarkNukeExtensions.Tests\DarkNukeExtensions.Tests.csproj", "{432A938F-C54F-4155-AE32-42E22DBE96D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +100,18 @@ Global
 		{9B5AE033-2D2D-4F80-99E4-49115DBA924F}.Release|iPhone.Build.0 = Release|Any CPU
 		{9B5AE033-2D2D-4F80-99E4-49115DBA924F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{9B5AE033-2D2D-4F80-99E4-49115DBA924F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Release|iPhone.Build.0 = Release|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{432A938F-C54F-4155-AE32-42E22DBE96D2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,6 +122,7 @@ Global
 		{740E6E43-8AA4-4602-9EF2-B65B47B3AA96} = {3D286D94-5DBD-42C0-8978-DD7122F4C02A}
 		{282DC7BA-CEEA-4D5C-BF1D-B1BCCC8F5996} = {3D286D94-5DBD-42C0-8978-DD7122F4C02A}
 		{9B5AE033-2D2D-4F80-99E4-49115DBA924F} = {3D286D94-5DBD-42C0-8978-DD7122F4C02A}
+		{432A938F-C54F-4155-AE32-42E22DBE96D2} = {3870B8E0-FDCF-420E-99B4-C6E3D8F567A9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E8BFD73B-47C2-4100-8D3E-A12770745C8A}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://github.com/michaldivis/dark-nuke-extensions/blob/v0.1.0-alpha/assets/icon.png?raw=true" width="100">
+
 # Dark NUKE Extensions
 
 A set of helper methods for publishing [Xamarin.Forms](https://xamarin.com/forms) Android and iOS apps using the [NUKE build system](https://nuke.build/).
@@ -38,7 +40,7 @@ MSBuild(o => o.PublishIosApp(new IosPublishSettings
     }));
 ```
 
-## Cleaning the bin and obj folders
+## Cleaning the `bin` and `obj` folders
 For whatever reason, the Xamarin.Android `bin` and `obj` folders would sometimes fail to be deleted when using the regular methods for deleting directories provided by Nuke. This method is a simple hard delete with a retry policy and it seems to work better for this purpose.
 
 ```csharp
@@ -48,11 +50,11 @@ DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.Android"), retryCount:
 ```
 
 ## Verbosity mapping
-Simple mapping of the Nuke `Verbosity` enum to `MSBuildVerbosity`.
+Simple mapping of the Nuke `Verbosity` enum to `MSBuildVerbosity`. Nuke accepts a verbosity parameter by default, that parameter is stored in the `Verbosity` property. Use this method in order to pass the verbosity setting to MSBuild.
 
 ```csharp
 using DarkNukeExtensions;
 
 Verbosity verbosity = Verbosity.Normal;
-var msBuildVerbosity = verbosity.ToMSBuildVerbosity();
+MSBuildVerbosity msBuildVerbosity = verbosity.ToMSBuildVerbosity();
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For whatever reason, the Xamarin.Android `bin` and `obj` folders would sometimes
 ```csharp
 using static DarkNukeExtensions.FileSystemTasks;
 
-DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.Android"), retryCount: 3);
+DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.Android").Directory, retryCount: 3);
 ```
 
 ## Verbosity mapping

--- a/sample/SampleBuild/Build.cs
+++ b/sample/SampleBuild/Build.cs
@@ -58,7 +58,7 @@ class Build : NukeBuild
     Target CleanAndroid => _ => _
         .Executes(() =>
         {
-            DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.Android"), retryCount: 3);
+            DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.Android").Directory, retryCount: 3);
         });
 
     Target Android => _ => _
@@ -82,7 +82,7 @@ class Build : NukeBuild
     Target CleaniOS => _ => _
         .Executes(() =>
         {
-            DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.iOS"), retryCount: 3);
+            DeleteBinAndObjDirectories(Solution.GetProject("SampleApp.iOS").Directory, retryCount: 3);
         });
 
     Target iOS => _ => _

--- a/src/DarkNukeExtensions/AndroidPublishSettings.cs
+++ b/src/DarkNukeExtensions/AndroidPublishSettings.cs
@@ -7,12 +7,12 @@ public class AndroidPublishSettings
     /// <summary>
     /// Target project path
     /// </summary>
-    public string TargetPath { get; init; }
+    public string? TargetPath { get; init; }
 
     /// <summary>
     /// Output directory the app bundle will be published to
     /// </summary>
-    public string OutDir { get; init; }
+    public string? OutDir { get; init; }
 
     /// <summary>
     /// Build configuration, defaults to Release

--- a/src/DarkNukeExtensions/AndroidPublishSettingsValidator.cs
+++ b/src/DarkNukeExtensions/AndroidPublishSettingsValidator.cs
@@ -9,7 +9,7 @@ public class AndroidPublishSettingsValidator : AbstractValidator<AndroidPublishS
         RuleFor(a => a.TargetPath)
             .Custom((targetPath, context) =>
             {
-                if (!FileSystemValidations.IsValidExistingCsprojFile(targetPath))
+                if (!FileSystemValidations.IsValidCsprojFilePath(targetPath))
                 {
                     context.AddFailure("Target path has to be a valid .csproj file path");
                 }

--- a/src/DarkNukeExtensions/AndroidPublishSettingsValidator.cs
+++ b/src/DarkNukeExtensions/AndroidPublishSettingsValidator.cs
@@ -1,0 +1,33 @@
+﻿using FluentValidation;
+
+namespace DarkNukeExtensions;
+
+public class AndroidPublishSettingsValidator : AbstractValidator<AndroidPublishSettings>
+{
+    public AndroidPublishSettingsValidator()
+    {
+        RuleFor(a => a.TargetPath)
+            .Custom((targetPath, context) =>
+            {
+                if (!FileSystemValidations.IsValidExistingCsprojFile(targetPath))
+                {
+                    context.AddFailure("Target path has to be a valid .csproj file path");
+                }
+            });
+
+        RuleFor(a => a.OutDir)
+            .Custom((outDir, context) =>
+            {
+                if (!FileSystemValidations.IsValidDirectoryPath(outDir))
+                {
+                    context.AddFailure("Output directory has to be a valid directory path");
+                }
+            });
+
+        RuleFor(a => a.Configuration)
+            .NotEmpty();
+
+        RuleFor(a => a.Verbosity)
+            .NotNull();
+    }
+}

--- a/src/DarkNukeExtensions/DarkNukeExtensions.csproj
+++ b/src/DarkNukeExtensions/DarkNukeExtensions.csproj
@@ -29,6 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Nuke.Common" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/DarkNukeExtensions/DarkNukeExtensions.csproj
+++ b/src/DarkNukeExtensions/DarkNukeExtensions.csproj
@@ -17,7 +17,7 @@
 	  <PackageReleaseNotes></PackageReleaseNotes>
 	  <PackageTags>nuke-build, xamarin-forms</PackageTags>
 	  <NeutralLanguage>en-US</NeutralLanguage>
-	  <Version>0.1.0-alpha</Version>
+	  <Version>0.2.0-alpha</Version>
 	  <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 

--- a/src/DarkNukeExtensions/FileSystemTasks.cs
+++ b/src/DarkNukeExtensions/FileSystemTasks.cs
@@ -2,6 +2,7 @@
 using Serilog;
 using System;
 using System.IO;
+using Ardalis.GuardClauses;
 
 namespace DarkNukeExtensions
 {
@@ -12,7 +13,8 @@ namespace DarkNukeExtensions
         /// </summary>
         public static void DeleteBinAndObjDirectories(Project project, int retryCount = 3)
         {
-            //TODO guard inputs
+            Guard.Against.Null(project);
+            Guard.Against.NegativeOrZero(retryCount);
 
             TryDeleteDirectory(project.Directory / "bin", retryCount);
             TryDeleteDirectory(project.Directory / "obj", retryCount);

--- a/src/DarkNukeExtensions/FileSystemTasks.cs
+++ b/src/DarkNukeExtensions/FileSystemTasks.cs
@@ -3,6 +3,7 @@ using Serilog;
 using System;
 using System.IO;
 using Ardalis.GuardClauses;
+using Nuke.Common.IO;
 
 namespace DarkNukeExtensions
 {
@@ -11,13 +12,13 @@ namespace DarkNukeExtensions
         /// <summary>
         /// Tries to delete the bin and obj directories of a project (with retries)
         /// </summary>
-        public static void DeleteBinAndObjDirectories(Project project, int retryCount = 3)
+        public static void DeleteBinAndObjDirectories(AbsolutePath projectDirectory, int retryCount = 3)
         {
-            Guard.Against.Null(project);
+            Guard.Against.NullOrEmpty(projectDirectory);
             Guard.Against.NegativeOrZero(retryCount);
 
-            TryDeleteDirectory(project.Directory / "bin", retryCount);
-            TryDeleteDirectory(project.Directory / "obj", retryCount);
+            TryDeleteDirectory(projectDirectory / "bin", retryCount);
+            TryDeleteDirectory(projectDirectory / "obj", retryCount);
         }
 
         private static void TryDeleteDirectory(string dirPath, int retryCount = 3)

--- a/src/DarkNukeExtensions/FileSystemValidations.cs
+++ b/src/DarkNukeExtensions/FileSystemValidations.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+
+namespace DarkNukeExtensions;
+
+public static class FileSystemValidations
+{
+    public static bool IsValidExistingCsprojFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(path);
+
+        if (string.IsNullOrEmpty(extension))
+        {
+            return false;
+        }
+
+        return extension.ToLower().Equals(".csproj");
+    }
+
+    public static bool IsValidDirectoryPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            Path.GetFullPath(path);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/src/DarkNukeExtensions/FileSystemValidations.cs
+++ b/src/DarkNukeExtensions/FileSystemValidations.cs
@@ -5,7 +5,7 @@ namespace DarkNukeExtensions;
 
 public static class FileSystemValidations
 {
-    public static bool IsValidExistingCsprojFile(string? path)
+    public static bool IsValidCsprojFilePath(string? path)
     {
         if (string.IsNullOrEmpty(path))
         {

--- a/src/DarkNukeExtensions/IosPublishSettings.cs
+++ b/src/DarkNukeExtensions/IosPublishSettings.cs
@@ -7,12 +7,12 @@ public class IosPublishSettings
     /// <summary>
     /// Target project path
     /// </summary>
-    public string TargetPath { get; init; }
+    public string? TargetPath { get; init; }
 
     /// <summary>
     /// Output directory the app bundle will be published to
     /// </summary>
-    public string OutDir { get; init; }
+    public string? OutDir { get; init; }
 
     /// <summary>
     /// Build configuration, defaults to Release
@@ -27,20 +27,20 @@ public class IosPublishSettings
     /// <summary>
     /// IPA package name, example: "MyAppPackage" will result in "MyAppPackage.ipa"
     /// </summary>
-    public string PackageName { get; init; }
+    public string? PackageName { get; init; }
 
     /// <summary>
     /// IP address of the MAC used to build the app
     /// </summary>
-    public string MacServerAddress { get; init; }
+    public string? MacServerAddress { get; init; }
 
     /// <summary>
     /// Username of the MAC used to build the app
     /// </summary>
-    public string MacServerUser { get; init; }
+    public string? MacServerUser { get; init; }
 
     /// <summary>
     /// User password of the MAC used to build the app
     /// </summary>
-    public string MacServerPassword { get; init; }
+    public string? MacServerPassword { get; init; }
 }

--- a/src/DarkNukeExtensions/IosPublishSettingsValidator.cs
+++ b/src/DarkNukeExtensions/IosPublishSettingsValidator.cs
@@ -9,7 +9,7 @@ public class IosPublishSettingsValidator : AbstractValidator<IosPublishSettings>
         RuleFor(a => a.TargetPath)
             .Custom((targetPath, context) =>
             {
-                if (!FileSystemValidations.IsValidExistingCsprojFile(targetPath))
+                if (!FileSystemValidations.IsValidCsprojFilePath(targetPath))
                 {
                     context.AddFailure("Target path has to be a valid .csproj file path");
                 }

--- a/src/DarkNukeExtensions/IosPublishSettingsValidator.cs
+++ b/src/DarkNukeExtensions/IosPublishSettingsValidator.cs
@@ -1,0 +1,45 @@
+﻿using FluentValidation;
+
+namespace DarkNukeExtensions;
+
+public class IosPublishSettingsValidator : AbstractValidator<IosPublishSettings>
+{
+    public IosPublishSettingsValidator()
+    {
+        RuleFor(a => a.TargetPath)
+            .Custom((targetPath, context) =>
+            {
+                if (!FileSystemValidations.IsValidExistingCsprojFile(targetPath))
+                {
+                    context.AddFailure("Target path has to be a valid .csproj file path");
+                }
+            });
+
+        RuleFor(a => a.OutDir)
+            .Custom((outDir, context) =>
+            {
+                if (!FileSystemValidations.IsValidDirectoryPath(outDir))
+                {
+                    context.AddFailure("Output directory has to be a valid directory path");
+                }
+            });
+
+        RuleFor(a => a.Configuration)
+            .NotEmpty();
+
+        RuleFor(a => a.Verbosity)
+            .NotNull();
+
+        RuleFor(a => a.PackageName)
+            .NotEmpty();
+
+        RuleFor(a => a.MacServerAddress)
+            .NotEmpty();
+
+        RuleFor(a => a.MacServerUser)
+            .NotEmpty();
+
+        RuleFor(a => a.MacServerPassword)
+            .NotEmpty();
+    }
+}

--- a/src/DarkNukeExtensions/MSBuildSettingsExtensions.cs
+++ b/src/DarkNukeExtensions/MSBuildSettingsExtensions.cs
@@ -4,12 +4,20 @@ namespace DarkNukeExtensions
 {
     public static class MSBuildSettingsExtensions
     {
+        private static AndroidPublishSettingsValidator? _androidPublishSettingsValidator;
+        private static AndroidPublishSettingsValidator GetAndroidPublishSettingsValidator() => _androidPublishSettingsValidator ??= new AndroidPublishSettingsValidator();
+
         /// <summary>
         /// Publish an Android app bundle
         /// </summary>
         public static MSBuildSettings PublishAndroidApp(this MSBuildSettings o, AndroidPublishSettings settings)
         {
-            //TODO validate settings
+            var validation = GetAndroidPublishSettingsValidator().Validate(settings);
+
+            if (!validation.IsValid)
+            {
+                throw new SettingsValidationException(validation.Errors);
+            }
 
             o.SetTargetPath(settings.TargetPath)
                .EnableRestore()
@@ -20,12 +28,20 @@ namespace DarkNukeExtensions
             return o;
         }
 
+        private static IosPublishSettingsValidator? _iosPublishSettingsValidator;
+        private static IosPublishSettingsValidator GetIosPublishSettingsValidator() => _iosPublishSettingsValidator ??= new IosPublishSettingsValidator();
+
         /// <summary>
         /// Publish an iOS IPA package
         /// </summary>
         public static MSBuildSettings PublishIosApp(this MSBuildSettings o, IosPublishSettings settings)
         {
-            //TODO validate settings
+            var validation = GetIosPublishSettingsValidator().Validate(settings);
+
+            if (!validation.IsValid)
+            {
+                throw new SettingsValidationException(validation.Errors);
+            }
 
             o.SetTargetPath(settings.TargetPath)
                 .EnableRestore()

--- a/src/DarkNukeExtensions/SettingsValidationException.cs
+++ b/src/DarkNukeExtensions/SettingsValidationException.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation.Results;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DarkNukeExtensions
+{
+    public class SettingsValidationException : Exception
+    {
+        public List<ValidationFailure> Errors { get; }
+
+        public SettingsValidationException(List<ValidationFailure> errors) : base(string.Join(", ", errors.Select(a => a.ErrorMessage)))
+        {
+            Errors = errors;
+        }
+    }
+}

--- a/tests/DarkNukeExtensions.Tests/DarkNukeExtensions.Tests.csproj
+++ b/tests/DarkNukeExtensions.Tests/DarkNukeExtensions.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>DarkNukeExtensions</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DarkNukeExtensions\DarkNukeExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DarkNukeExtensions.Tests/FileSystemTasksTests.cs
+++ b/tests/DarkNukeExtensions.Tests/FileSystemTasksTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+using Nuke.Common;
+using Nuke.Common.IO;
+using System;
+using Xunit;
+
+namespace DarkNukeExtensions;
+
+public class FileSystemTasksTests
+{
+    private readonly AbsolutePath _validProjectDirectory = EnvironmentInfo.WorkingDirectory / "MyProject";
+    private const int _validRetryCount = 3;
+
+    [Fact]
+    public void DeleteBinAndObjDirectories_ShouldNotThrow_WhenParamsValid()
+    {
+        Action act = () => FileSystemTasks.DeleteBinAndObjDirectories(_validProjectDirectory, _validRetryCount);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DeleteBinAndObjDirectories_ShouldThrow_WhenProjectDirectoryNull()
+    {
+        Action act = () => FileSystemTasks.DeleteBinAndObjDirectories(null!, _validRetryCount);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void DeleteBinAndObjDirectories_ShouldThrow_WhenProjectDirectoryEmpty()
+    {
+        Action act = () => FileSystemTasks.DeleteBinAndObjDirectories((AbsolutePath)string.Empty, _validRetryCount);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void DeleteBinAndObjDirectories_ShouldThrow_WhenRetryCountNegative()
+    {
+        Action act = () => FileSystemTasks.DeleteBinAndObjDirectories(_validProjectDirectory, -5);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void DeleteBinAndObjDirectories_ShouldThrow_WhenRetryCountZero()
+    {
+        Action act = () => FileSystemTasks.DeleteBinAndObjDirectories(_validProjectDirectory, 0);
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/DarkNukeExtensions.Tests/MSBuildSettingsExtensionsTests.cs
+++ b/tests/DarkNukeExtensions.Tests/MSBuildSettingsExtensionsTests.cs
@@ -1,0 +1,288 @@
+using FluentAssertions;
+using Nuke.Common.Tools.MSBuild;
+using System;
+using Xunit;
+
+namespace DarkNukeExtensions;
+
+public class MSBuildSettingsExtensionsTests
+{
+    private const string _validConfiguration = "Release";
+    private readonly MSBuildVerbosity _validVerbosity = MSBuildVerbosity.Normal;
+    private const string _validTargetPath = @"C:/Projects/Something/Something.csproj";
+    private const string _validOutDir = @"C:/Projects/Something/artifacts";
+    private const string _validPackageName = "MyApp"; 
+    private const string _validMacAddress = "MacAddress";
+    private const string _validMacUsername = "MacUsername";
+    private const string _validMacPassword = "MacPassword";
+
+    #region PublishAndroidApp
+
+    [Fact]
+    public void PublishAndroidApp_ShouldNotThrow_WhenSettingsValid()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir
+        });
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void PublishAndroidApp_ShouldThrow_WhenSettingsEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings());
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishAndroidApp_ShouldThrow_WhenConfigurationEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings
+        {
+            Configuration = string.Empty,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishAndroidApp_ShouldThrow_WhenVerbosityNull()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = null!,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishAndroidApp_ShouldThrow_WhenTargetPathEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = string.Empty,
+            OutDir = _validOutDir
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishAndroidApp_ShouldThrow_WhenTargetPathInvalid()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = @"C:/Invalid/Path/Example.pdf",
+            OutDir = _validOutDir
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishAndroidApp_ShouldThrow_WhenOutDirEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishAndroidApp(new AndroidPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = string.Empty
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    #endregion
+
+    #region PublishIosApp
+
+    [Fact]
+    public void PublishIosApp_ShouldNotThrow_WhenSettingsValid()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenSettingsEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings());
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenConfigurationEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = string.Empty,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenVerbosityNull()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = null!,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenTargetPathEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = string.Empty,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenTargetPathInvalid()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = @"C:/Invalid/Path/Example.pdf",
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenOutDirEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = string.Empty,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenPackageNameEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = string.Empty,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenMacAddressEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = string.Empty,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenMacUsernameEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = string.Empty,
+            MacServerPassword = _validMacPassword
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    [Fact]
+    public void PublishIosApp_ShouldThrow_WhenMacPasswordEmpty()
+    {
+        Action act = () => new MSBuildSettings().PublishIosApp(new IosPublishSettings
+        {
+            Configuration = _validConfiguration,
+            Verbosity = _validVerbosity,
+            TargetPath = _validTargetPath,
+            OutDir = _validOutDir,
+            PackageName = _validPackageName,
+            MacServerAddress = _validMacAddress,
+            MacServerUser = _validMacUsername,
+            MacServerPassword = string.Empty
+        });
+        act.Should().Throw<SettingsValidationException>();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
# News
## Settings Validation
The `MSBuildSettingsExtensions.PublishAndroidApp` and `MSBuildSettingsExtensions.PublishIosApp` now validate the settings that are passed in and throw a `SettingsValidationException` if the settings contain invalid values.

# Changes
## `DeleteBinAndObjDirectories` signature
The `FileSystemTasks.DeleteBinAndObjDirectories` now takes in a `AbsolutePath` instead of a `Project`.

changed

```csharp
void DeleteBinAndObjDirectories(Project project, int retryCount = 3);
```

to

```csharp
void DeleteBinAndObjDirectories(AbsolutePath projectDirectory, int retryCount = 3);
```

